### PR TITLE
added decoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ LIB_DIRS += ${SRC_DIR}/cmp
 LIB_DIRS += ${SRC_DIR}/add
 LIB_DIRS += ${SRC_DIR}/mult
 LIB_DIRS += ${SRC_DIR}/mux
+LIB_DIRS += ${SRC_DIR}/dec
 
 ADD_TEST=${TEST_DIR}/test_add.v
 SUB_TEST=${TEST_DIR}/test_sub.v
 MULT_TEST=${TEST_DIR}/test_mult.v
+DEC_TEST=${TEST_DIR}/test_dec.v
 MUX_TEST=${TEST_DIR}/test_mux.v
 SHIFT_TEST=${TEST_DIR}/test_shift.v
 CMP_TEST=${TEST_DIR}/test_cmp.v
@@ -22,7 +24,7 @@ define compile
   ${VERILOG} $(addprefix -y, ${LIB_DIRS}) -o ${BIN_DIR}/$(notdir $(basename $1))$1
 endef
 
-all: bin add mux shift cmp mult
+all: bin add mult mux shift cmp dec
 
 add:
 	$(call compile, ${ADD_TEST})
@@ -30,6 +32,9 @@ add:
 
 mult:
 	$(call compile, ${MULT_TEST})
+
+dec:
+	$(call compile, ${DEC_TEST})
 
 mux:
 	$(call compile, ${MUX_TEST})

--- a/src/dec/dec.v
+++ b/src/dec/dec.v
@@ -1,0 +1,13 @@
+module dec (out, in);
+
+output wire [15:0] out;
+input wire [3:0] in;
+
+wire _in_msb;
+
+not (_in_msb, in[3]);
+
+dec_3x8 lower (out[7:0], in[2:0], _in_msb);
+dec_3x8 upper (out[15:8], in[2:0], in[3]);
+
+endmodule

--- a/src/dec/dec_3x8.v
+++ b/src/dec/dec_3x8.v
@@ -1,0 +1,20 @@
+module dec_3x8 (out, in, E);
+
+output wire [7:0] out;
+input wire [2:0] in;
+input wire E;
+
+wire [2:0] _in;
+
+not not_in [2:0] (_in[2:0], in[2:0]);
+
+and (out[0], _in[2], _in[1], _in[0], E);
+and (out[1], _in[2], _in[1], in[0], E);
+and (out[2], _in[2], in[1], _in[0], E);
+and (out[3], _in[2], in[1], in[0], E);
+and (out[4], in[2], _in[1], _in[0], E);
+and (out[5], in[2], _in[1], in[0], E);
+and (out[6], in[2], in[1], _in[0], E);
+and (out[7], in[2], in[1], in[0], E);
+
+endmodule

--- a/src/test/test_dec.v
+++ b/src/test/test_dec.v
@@ -1,0 +1,20 @@
+module test_dec ();
+
+reg [3:0] A;
+wire [15:0] out;
+
+dec dec_test (out, A);
+
+integer i;
+initial begin
+  for (i = 0; i < 16; i = i + 1) begin
+    if (i) #10;
+    A <= i[3:0];
+  end
+end
+
+initial begin
+  $monitor("dec: %2d => %16b", A, out);
+end
+
+endmodule


### PR DESCRIPTION
Addresses #16 

I added a decoder using two 3x8 decoders.

The 4x16 decoder that is referred to as just `dec` does not have an enable line. If we find that we need a higher order decoder, a separate module with an enable line can be added.